### PR TITLE
feat: allow to parameterize mcp transport

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,5 @@ EXPOSE 8080
 ENV PATH="/app/.venv/bin:$PATH"
 
 # Run the application
-CMD ["fastmcp", "run", "main.py", "--transport", "streamable-http", "--port", "8080"]
+ENV MCP_TRANSPORT=streamable-http
+CMD ["uv", "run", "main.py"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -26,4 +26,6 @@ services:
     network_mode: service:ts-serve-echo-mcp
     depends_on:
       - ts-serve-echo-mcp
+    environment:
+      - MCP_TRANSPORT=${MCP_TRANSPORT:-streamable-http}
     restart: unless-stopped

--- a/main.py
+++ b/main.py
@@ -1,25 +1,35 @@
+import os
+import sys
 from fastmcp import FastMCP
 from fastmcp.server.dependencies import get_http_request
 from starlette.requests import Request
 
-mcp = FastMCP(name="Tailscale Identity Echo Server")
+transport = os.getenv("MCP_TRANSPORT", "streamable-http").strip()
 
+# Validate transport
+if transport not in {"streamable-http", "sse"}:
+    print(f"ERROR: Unsupported transport '{transport}'", file=sys.stderr)
+    sys.exit(1)
+
+mcp = FastMCP(name="Tailscale Identity Echo Server")
 
 @mcp.tool()
 async def greet() -> str:
-    """Reads the indentity request headers passed in from Tailscale Serve and returns a greeting.
+    req: Request = get_http_request()
+    return (
+        f"Hello, {req.headers.get('Tailscale-User-Name','Unknown')}! "
+        f"You are logged in as {req.headers.get('Tailscale-User-Login','Unknown')}."
+    )
 
-    Returns:
-        str: A greeting containing the user's name, login (typically an email or Github handle),
-        and profile picture URL.
-    """
+def main():
+    print(f"Starting FastMCP with transport={transport}", file=sys.stderr)
+    try:
+        mcp.run(transport=transport, port=8080, host="0.0.0.0")
+    except Exception as e:
+        print(f"FATAL: Server startup failed: {e}", file=sys.stderr)
+        sys.exit(1)
+    print("i exit")
 
-    request: Request = get_http_request()
-
-    user_login = request.headers.get("Tailscale-User-Login", "Unknown")
-    user_name = request.headers.get("Tailscale-User-Name", "Unknown")
-    user_profile_picture = request.headers.get("Tailscale-User-Profile-Pic", "Unknown")
-
-    return f"""Hello, {user_name}!
-You're logged in to Tailscale as {user_login}.
-With a profile picture at this URL: {user_profile_picture}."""
+# When run with "python main.py", this fires.
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Modify the docker entrypoint and main to allow accepting env vars for transport. Allow some more detailed control of errors and output